### PR TITLE
Wrap the kyverno templates to prevent ACM from trying to process them

### DIFF
--- a/config/input/kyverno/validate/block-updates-deletes.yaml
+++ b/config/input/kyverno/validate/block-updates-deletes.yaml
@@ -16,10 +16,10 @@ spec:
       clusterRoles:
       - cluster-admin
     validate:
-      message: "Modifying or deleting the external customer resource {{request.oldObject.kind}}/{{request.oldObject.metadata.name}} is not allowed. Please seek a cluster-admin."
+      message: "Modifying or deleting the external customer resource {{ `{{request.oldObject.kind}}` }}/{{ `{{request.oldObject.metadata.name}}` }} is not allowed. Please seek a cluster-admin."
       deny:
         conditions:
-          - key: "{{request.operation}}"
+          - key: "{{ `{{request.operation}}` }}"
             operator: In
             value: 
             - DELETE

--- a/config/input/kyverno/validate/check_deprecated_apis.yaml
+++ b/config/input/kyverno/validate/check_deprecated_apis.yaml
@@ -44,7 +44,7 @@ spec:
         - storage.k8s.io/v1beta1/VolumeAttachment
     validate:
       message: >-
-        {{ request.object.apiVersion }}/{{ request.object.kind }} is deprecated and will be removed in v1.22.
+        {{ `{{ request.object.apiVersion }}` }}/{{ `{{ request.object.kind }}` }} is deprecated and will be removed in v1.22.
         See: https://kubernetes.io/docs/reference/using-api/deprecation-guide/
       deny: {}
   - name: validate-v1-25-removals
@@ -59,6 +59,6 @@ spec:
         - node.k8s.io/v1beta1/RuntimeClass
     validate:
       message: >-
-        {{ request.object.apiVersion }}/{{ request.object.kind }} is deprecated and will be removed in v1.25.
+        {{ `{{ request.object.apiVersion }}` }}/{{ `{{ request.object.kind }}` }} is deprecated and will be removed in v1.25.
         See: https://kubernetes.io/docs/reference/using-api/deprecation-guide/
       deny: {}

--- a/config/input/kyverno/validate/disallow_empty_ingress_host.yaml
+++ b/config/input/kyverno/validate/disallow_empty_ingress_host.yaml
@@ -24,6 +24,6 @@ spec:
         message: "The Ingress host name must be defined, not empty."
         deny:
           conditions:
-            - key: "{{ request.object.spec.rules[].host || `[]` | length(@) }}"
+            - key: "{{ `{{ request.object.spec.rules[].host || `[]` | length(@) }}` }}"
               operator: NotEquals
-              value: "{{ request.object.spec.rules[].http || `[]` | length(@) }}"
+              value: "{{ `{{ request.object.spec.rules[].http || `[]` | length(@) }}` }}"

--- a/config/input/kyverno/validate/openshift/check-routes.yaml
+++ b/config/input/kyverno/validate/openshift/check-routes.yaml
@@ -24,7 +24,7 @@ spec:
               - route.openshift.io/v1/Route
       preconditions:
         all:
-        - key: "{{ request.operation }}"
+        - key: "{{ `{{ request.operation }}` }}"
           operator: NotEquals
           value: ["DELETE"]
       validate:
@@ -33,7 +33,7 @@ spec:
         deny:
           conditions:
             all:
-            - key: "{{ keys(request.object.spec) | contains(@, 'tls') }}"
+            - key: "{{ `{{ keys(request.object.spec) | contains(@, 'tls') }}` }}"
               operator: Equals
               value: false
 

--- a/config/input/kyverno/validate/openshift/disallow-deprecated-apis.yaml
+++ b/config/input/kyverno/validate/openshift/disallow-deprecated-apis.yaml
@@ -31,5 +31,5 @@ spec:
           - authorization.openshift.io/v1/RoleBinding
     validate:
       message: >-
-        {{ request.object.apiVersion }}/{{ request.object.kind }} is deprecated.
+        {{ `{{ request.object.apiVersion }}` }}/{{ `{{ request.object.kind }}` }} is deprecated.
       deny: {}

--- a/config/input/kyverno/validate/openshift/disallow-jenkins-pipeline-strategy.yaml
+++ b/config/input/kyverno/validate/openshift/disallow-jenkins-pipeline-strategy.yaml
@@ -29,6 +29,6 @@ spec:
       deny: 
         conditions:
           all:
-          - key: "{{ keys(request.object.spec.strategy) | contains(@, 'jenkinsPipelineStrategy') }}"
+          - key: "{{ `{{ keys(request.object.spec.strategy) | contains(@, 'jenkinsPipelineStrategy') }}` }}"
             operator: Equals
             value: true

--- a/config/input/kyverno/validate/openshift/disallow-security-context-constraint-anyuid.yaml
+++ b/config/input/kyverno/validate/openshift/disallow-security-context-constraint-anyuid.yaml
@@ -33,8 +33,8 @@ spec:
             all:
             - key: anyuid
               operator: AnyIn
-              value: "{{element.resourceNames[]}}"
-            - key: "{{ element.verbs[]  | contains(@, 'use') || contains(@, '*') }}"
+              value: "{{ `{{element.resourceNames[]}}` }}"
+            - key: "{{ `{{ element.verbs[]  | contains(@, 'use') || contains(@, '*') }}` }}"
               operator: Equals
               value: true
   - name: check-security-context-roleref
@@ -52,4 +52,4 @@ spec:
           all:
           - key: system:openshift:scc:anyuid
             operator: Equals
-            value: "{{request.object.roleRef.name}}"
+            value: "{{ `{{request.object.roleRef.name}}` }}"

--- a/config/input/kyverno/validate/openshift/disallow-self-provisioner-binding.yaml
+++ b/config/input/kyverno/validate/openshift/disallow-self-provisioner-binding.yaml
@@ -24,10 +24,10 @@ spec:
           - ClusterRoleBinding
     preconditions:
       all:
-      - key: "{{request.object.metadata.name}}"
+      - key: "{{ `{{request.object.metadata.name}}` }}"
         operator: Equals
         value: self-provisioners
-      - key: "{{request.operation}}"
+      - key: "{{ `{{request.operation}}` }}"
         operator: Equals
         value: UPDATE
     validate:
@@ -43,7 +43,7 @@ spec:
           - ClusterRoleBinding
     preconditions:
       all:
-      - key: "{{request.object.metadata.name || ''}}"
+      - key: "{{ `{{request.object.metadata.name || ''}}` }}"
         operator: NotEquals
         value: self-provisioners
     validate:
@@ -54,4 +54,4 @@ spec:
           all:
           - key: self-provisioner
             operator: In
-            value: "{{request.object.roleRef.name}}"
+            value: "{{ `{{request.object.roleRef.name}}` }}"

--- a/config/input/kyverno/validate/openshift/enforce-etcd-encryption.yaml
+++ b/config/input/kyverno/validate/openshift/enforce-etcd-encryption.yaml
@@ -28,6 +28,6 @@ spec:
       deny: 
         conditions:
           all:
-          - key: "{{ keys(request.object.spec) | contains(@, 'encryption') }}"
+          - key: "{{ `{{ keys(request.object.spec) | contains(@, 'encryption') }}` }}"
             operator: NotEquals
             value: true

--- a/config/input/kyverno/validate/require_drop_all.yaml
+++ b/config/input/kyverno/validate/require_drop_all.yaml
@@ -25,7 +25,7 @@ spec:
               - Pod
       preconditions:
         all:
-        - key: "{{ request.operation }}"
+        - key: "{{ `{{ request.operation }}` }}"
           operator: NotEquals
           value: DELETE
       validate:
@@ -38,4 +38,4 @@ spec:
                 all:
                 - key: ALL
                   operator: AnyNotIn
-                  value: "{{ element.securityContext.capabilities.drop || '' }}"
+                  value: "{{ `{{ element.securityContext.capabilities.drop || '' }}` }}"


### PR DESCRIPTION
ACM thinks it owns templates.  Kyverno thinks it owns them.  Since ACM
processes the policy first, and the templates are for kyverno -- we
see errors.  This PR addresses this problem by wrapping the templates
so ACM does nothing with them and then they get passed to Kyverno
properly.

Signed-off-by: Gus Parvin <gparvin@redhat.com>